### PR TITLE
add shipment to docker compose

### DIFF
--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -210,6 +210,24 @@ services:
     volumes:
       - "./.dapr/dapr-config.yaml:/config.yaml"
       - "./.dapr/components:/components"
+  
+  shipment:
+    extends:
+      file: shipment/docker-compose-base.yaml
+      service: shipment
+    environment:
+      - MISARCH_SHIPMENT_PROVIDER_ENDPOINT=http://localhost/TODO
+  shipment-db:
+    extends:
+      file: shipment/docker-compose-base.yaml
+      service: shipment-db
+  shipment-dapr:
+    extends:
+      file: shipment/docker-compose-base.yaml
+      service: shipment-dapr
+    volumes:
+      - "./.dapr/dapr-config.yaml:/config.yaml"
+      - "./.dapr/components:/components"
 
   placement:
     image: daprio/dapr
@@ -261,3 +279,4 @@ volumes:
   review-db-data:
   address-db-data:
   discount-db-data:
+  shipment-db-data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -224,6 +224,25 @@ services:
       - "./.dapr/dapr-config.yaml:/config.yaml"
       - "./.dapr/components:/components"
   
+  shipment:
+    extends:
+      file: shipment/docker-compose-base.yaml
+      service: shipment
+    image: ghcr.io/misarch/shipment:main
+    environment:
+      - MISARCH_SHIPMENT_PROVIDER_ENDPOINT=http://localhost/TODO
+  shipment-db:
+    extends:
+      file: shipment/docker-compose-base.yaml
+      service: shipment-db
+  shipment-dapr:
+    extends:
+      file: shipment/docker-compose-base.yaml
+      service: shipment-dapr
+    volumes:
+      - "./.dapr/dapr-config.yaml:/config.yaml"
+      - "./.dapr/components:/components"
+
   placement:
     image: daprio/dapr
     command: ["./placement", "-port", "50006"]
@@ -274,3 +293,4 @@ volumes:
   review-db-data:
   address-db-data:
   discount-db-data:
+  shipment-db-data:


### PR DESCRIPTION
https://frontend.gropius.duckdns.org/components/2571e2de-a0e7-4017-b721-2fd3692ad5d6/issues/f6203c56-7c1f-4792-b3a0-eb8b88118cee

Note: currently the URL of the external provider is TODO, as this service does not exist yet

DoD:
- [x] Requirements of the issue are met
- [x] Code has been reviewed
- [x] Code is documented
- [x] GraphQL related artefacts are documented